### PR TITLE
Makes zones a first class model in the system.

### DIFF
--- a/app/assets/javascripts/zones.js.coffee
+++ b/app/assets/javascripts/zones.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/zones.css.scss
+++ b/app/assets/stylesheets/zones.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the zones controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -1,0 +1,78 @@
+class ZonesController < ApplicationController
+  before_filter :require_user
+
+  before_action :set_zone, only: [:show, :edit, :update, :destroy]
+
+  # GET /zones
+  # GET /zones.json
+  def index
+    store_listing_referer
+
+    @zones = Zone.all
+  end
+
+  # GET /zones/1
+  # GET /zones/1.json
+  def show
+  end
+
+  # GET /zones/new
+  def new
+    @zone = Zone.new
+  end
+
+  # GET /zones/1/edit
+  def edit
+  end
+
+  # POST /zones
+  # POST /zones.json
+  def create
+    @zone = Zone.new(zone_params)
+
+    respond_to do |format|
+      if @zone.save
+        format.html { redirect_to @zone, notice: 'Zone was successfully created.' }
+        format.json { render action: 'show', status: :created, location: @zone }
+      else
+        format.html { render action: 'new' }
+        format.json { render json: @zone.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /zones/1
+  # PATCH/PUT /zones/1.json
+  def update
+    respond_to do |format|
+      if @zone.update(zone_params)
+        format.html { redirect_to @zone, notice: 'Zone was successfully updated.' }
+        format.json { head :no_content }
+      else
+        format.html { render action: 'edit' }
+        format.json { render json: @zone.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /zones/1
+  # DELETE /zones/1.json
+  def destroy
+    @zone.destroy
+    respond_to do |format|
+      format.html { redirect_to zones_url }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_zone
+      @zone = Zone.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def zone_params
+      params.require(:zone).permit(:id, :name, :description)
+    end
+end

--- a/app/helpers/zones_helper.rb
+++ b/app/helpers/zones_helper.rb
@@ -1,0 +1,2 @@
+module ZonesHelper
+end

--- a/app/models/adoption_request.rb
+++ b/app/models/adoption_request.rb
@@ -1,6 +1,7 @@
 class AdoptionRequest < ActiveRecord::Base
   belongs_to :created_by, :class_name => "User", :foreign_key => "user_id"
   belongs_to :tree_species, :class_name => "Tree", :foreign_key => "tree_id"
+  belongs_to :zone
   has_many :plantings, dependent: :destroy
 
   validates :received_on, :house_number, :street_name, :user_id, :presence => true

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,0 +1,2 @@
+class Zone < ActiveRecord::Base
+end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,2 +1,4 @@
 class Zone < ActiveRecord::Base
+  belongs_to :created_by, :class_name => "User", :foreign_key => "user_id"
+  has_many :adoption_requests
 end

--- a/app/views/shared/_page_header.html.slim
+++ b/app/views/shared/_page_header.html.slim
@@ -7,7 +7,7 @@ nav class="navbar navbar-default"
         span class="icon-bar"
         span class="icon-bar"
         span class="icon-bar"
-      = link_to image_tag("rt_logo_web_header.png", :alt => "Richmond Trees Logo", height: "50px"), home_path, class: "navbar-brand" 
+      = link_to image_tag("rt_logo_web_header.png", :alt => "Richmond Trees Logo", height: "50px"), home_path, class: "navbar-brand"
     div class="collapse navbar-collapse" id="navlinks"
       ul class="nav navbar-nav navbar-right"
         li class=(controller == 'homepage' ? 'active' : '')
@@ -18,11 +18,13 @@ nav class="navbar navbar-default"
           = link_to "Plantings", plantings_path
         li class=(controller == 'trees' ? 'active' : '')
           = link_to "Trees", trees_path
+        li class=(controller == 'zones' ? 'active' : '')
+          = link_to "Zones", zones_path
         li class=(controller == 'users' ? 'active' : '')
           = link_to "Users", users_path
         li class=(controller == 'reports' ? 'active dropdown reports-nav-link' : 'dropdown reports-nav-link')
           a class="dropdown-toggle" data-toggle="dropdown"
-            | Reports 
+            | Reports
             span class="caret"
           ul class="dropdown-menu"
             li
@@ -30,6 +32,6 @@ nav class="navbar navbar-default"
             li
               = link_to "Adoption Requests Report", reports_adoption_requests_path
         li
-          = link_to(logout_path) do 
+          = link_to(logout_path) do
             span class="glyphicon glyphicon-log-out logout-icon" aria-hidden="true"
 /! page header end

--- a/app/views/zones/_form.html.slim
+++ b/app/views/zones/_form.html.slim
@@ -1,0 +1,12 @@
+div class="row"
+  div class="col-xs-12 col-md-6"
+    = bootstrap_form_for @zone do |f|
+      - if @zone.errors.any?
+        #error_explanation
+          h2 = "#{pluralize(@zone.errors.count, "error")} prohibited this zone from being saved:"
+          ul
+            - @zone.errors.full_messages.each do |message|
+              li = message
+      = f.text_field :name
+      = f.text_field :description
+      = f.submit

--- a/app/views/zones/edit.html.slim
+++ b/app/views/zones/edit.html.slim
@@ -1,0 +1,8 @@
+div class="container-fluid"
+  div class="row"
+    div class="col-xs-12"
+      h2 class="header-inline"
+        | Edit Zone
+      = render partial: 'shared/back_to_listing'
+  br
+  == render 'form'

--- a/app/views/zones/index.html.slim
+++ b/app/views/zones/index.html.slim
@@ -1,0 +1,39 @@
+div class="container-fluid"
+  div class="row"
+    div class="col-xs-8 col-md-9"
+      h2 class="header-inline"
+        | Zones
+      medium
+        | (&nbsp;
+        = @zones.count
+        | &nbsp;total&nbsp;)
+    div class="col-xs-4 col-md-3"
+      div class="text-right"
+        | (&nbsp;
+        = link_to 'Add New Zone', new_zone_path, class: "text-right"
+        | &nbsp;)
+    div class="col-xs-12 text-right"
+      = link_to zones_path( format: :csv ) do
+        button class="btn btn-default" Export to CSV
+  div class="row"
+    div class="col-xs-12"
+      div class="table-responsive"
+        table class="table table-hover"
+          thead
+            tr
+              th Id
+              th Name
+              th Description
+
+          tbody
+            - @zones.each do |zone|
+              tr
+                td = zone.id
+                td = zone.name
+                td = zone.description
+                td
+                  ul
+                    li = link_to 'Details', zone
+                    li = link_to 'Edit', edit_zone_path(zone)
+                    li = link_to 'Delete', zone, data: {:confirm => 'Are you sure?'}, :method => :delete
+

--- a/app/views/zones/index.json.jbuilder
+++ b/app/views/zones/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@zones) do |zone|
+  json.extract! zone, :id, :id, :name, :description
+  json.url zone_url(zone, format: :json)
+end

--- a/app/views/zones/new.html.slim
+++ b/app/views/zones/new.html.slim
@@ -1,0 +1,8 @@
+div class="container-fluid"
+  div class="row"
+    div class="col-xs-12"
+      h2 class="header-inline"
+        | Add a New Zone
+      = render partial: 'shared/back_to_listing'
+  br
+  == render 'form'

--- a/app/views/zones/show.html.slim
+++ b/app/views/zones/show.html.slim
@@ -1,0 +1,30 @@
+div class="container-fluid"
+  div class="row"
+    div class="col-xs-8 col-md-9"
+      h2 class="header-inline"
+        | Zone Details
+      = render partial: 'shared/back_to_listing'
+    div class="col-xs-4 col-md-3"
+      div class="text-right"
+        medium
+          | (
+          = link_to 'Edit', edit_zone_path(@zone)
+          | &nbsp;|&nbsp;
+          = link_to 'Delete', @zone, data: {:confirm => 'Are you sure?'}, :method => :delete
+          |  )
+  br
+  div class="row edit-row"
+    div class="col-xs-4 col-md-2 text-right"
+      strong ID
+    div class="col-xs-8 col-md-4"
+      = @zone.id
+  div class="row edit-row"
+    div class="col-xs-4 col-md-2 text-right"
+      strong Name
+    div class="col-xs-8 col-md-4"
+      = @zone.name
+  div class="row edit-row"
+    div class="col-xs-4 col-md-2 text-right"
+      strong Description
+    div class="col-xs-8 col-md-4"
+      = @zone.description

--- a/app/views/zones/show.json.jbuilder
+++ b/app/views/zones/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! @zone, :id, :id, :name, :description, :created_at, :updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 RichmondTreesAdmin::Application.routes.draw do
+  resources :zones
+
   post 'map', :controller => 'map', :action => 'index'
 
   resources :notes, except: :edit

--- a/db/migrate/20151219054618_create_zones.rb
+++ b/db/migrate/20151219054618_create_zones.rb
@@ -1,0 +1,10 @@
+class CreateZones < ActiveRecord::Migration
+  def change
+    create_table :zones do |t|
+      t.string :name
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151219054618) do
+ActiveRecord::Schema.define(version: 20151221064132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,9 +46,11 @@ ActiveRecord::Schema.define(version: 20151219054618) do
     t.string   "zone",                                         default: "", null: false
     t.decimal  "latitude",            precision: 10, scale: 6
     t.decimal  "longitude",           precision: 10, scale: 6
+    t.integer  "zone_id"
   end
 
   add_index "adoption_requests", ["user_id"], name: "index_adoption_requests_on_user_id", using: :btree
+  add_index "adoption_requests", ["zone_id"], name: "index_adoption_requests_on_zone_id", using: :btree
 
   create_table "maintenance_records", force: true do |t|
     t.string   "status_code"
@@ -146,10 +148,14 @@ ActiveRecord::Schema.define(version: 20151219054618) do
     t.string   "description"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "user_id"
   end
+
+  add_index "zones", ["user_id"], name: "index_zones_on_user_id", using: :btree
 
   add_foreign_key "adoption_requests", "trees", name: "adoption_requests_tree_id_fk"
   add_foreign_key "adoption_requests", "users", name: "adoption_requests_user_id_fk"
+  add_foreign_key "adoption_requests", "zones", name: "adoption_requests_zone_id_fk"
 
   add_foreign_key "maintenance_records", "plantings", name: "maintenance_records_planting_id_fk", dependent: :delete
   add_foreign_key "maintenance_records", "users", name: "maintenance_records_user_id_fk"
@@ -162,5 +168,7 @@ ActiveRecord::Schema.define(version: 20151219054618) do
   add_foreign_key "plantings", "users", name: "plantings_user_id_fk"
 
   add_foreign_key "trees", "users", name: "trees_user_id_fk"
+
+  add_foreign_key "zones", "users", name: "zones_user_id_fk"
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151008043531) do
+ActiveRecord::Schema.define(version: 20151219054618) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,6 +140,13 @@ ActiveRecord::Schema.define(version: 20151008043531) do
   add_index "users", ["last_request_at"], name: "index_users_on_last_request_at", using: :btree
   add_index "users", ["persistence_token"], name: "index_users_on_persistence_token", using: :btree
   add_index "users", ["username"], name: "index_users_on_username", using: :btree
+
+  create_table "zones", force: true do |t|
+    t.string   "name"
+    t.string   "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   add_foreign_key "adoption_requests", "trees", name: "adoption_requests_tree_id_fk"
   add_foreign_key "adoption_requests", "users", name: "adoption_requests_user_id_fk"

--- a/test/controllers/zones_controller_test.rb
+++ b/test/controllers/zones_controller_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class ZonesControllerTest < ActionController::TestCase
+  setup do
+    # authenticate
+    activate_authlogic
+    UserSession.create(users(:testuser1))
+
+    @zone = zones(:one)
+  end
+
+  test "should get index" do
+    get :index
+    assert_response :success
+    assert_not_nil assigns(:zones)
+  end
+
+  test "should get new" do
+    get :new
+    assert_response :success
+  end
+
+  test "should create zone" do
+    assert_difference('Zone.count') do
+      post :create, zone: { description: @zone.description, name: @zone.name }
+    end
+
+    assert_redirected_to zone_path(assigns(:zone))
+  end
+
+  test "should show zone" do
+    get :show, id: @zone
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get :edit, id: @zone
+    assert_response :success
+  end
+
+  test "should update zone" do
+    patch :update, id: @zone, zone: { description: @zone.description, name: @zone.name }
+    assert_redirected_to zone_path(assigns(:zone))
+  end
+
+  test "should destroy zone" do
+    assert_difference('Zone.count', -1) do
+      delete :destroy, id: @zone
+    end
+
+    assert_redirected_to zones_path
+  end
+end

--- a/test/fixtures/zones.yml
+++ b/test/fixtures/zones.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  description: MyString
+
+two:
+  name: MyString
+  description: MyString

--- a/test/helpers/zones_helper_test.rb
+++ b/test/helpers/zones_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class ZonesHelperTest < ActionView::TestCase
+end

--- a/test/models/zone_test.rb
+++ b/test/models/zone_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ZoneTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Before, zones were identified by an arbitrary text field on adoption requests.  Changing zones to a first class model will make them easier to work with and extend (if it is decided to do so).
