### PR TITLE
Closes #22.  Don't remove deleted records from the database.

### DIFF
--- a/app/controllers/adoption_requests_controller.rb
+++ b/app/controllers/adoption_requests_controller.rb
@@ -14,10 +14,10 @@ class AdoptionRequestsController < ApplicationController
     include_completed = params[:adoption_request][:include_completed] unless params[:adoption_request].nil?
 
     if include_completed == "1"
-      @adoption_requests = AdoptionRequest.includes( :zone ).load
+      @adoption_requests = AdoptionRequest.includes( :zone ).where.not( ignore: true ).load
       @include_completed_checked = "checked"
     else
-      @adoption_requests = AdoptionRequest.includes( :zone ).where( :completed => false )
+      @adoption_requests = AdoptionRequest.includes( :zone ).where( :completed => false ).where.not( ignore: true )
       @include_completed_checked = ""
     end
   end

--- a/app/controllers/adoption_requests_controller.rb
+++ b/app/controllers/adoption_requests_controller.rb
@@ -14,10 +14,10 @@ class AdoptionRequestsController < ApplicationController
     include_completed = params[:adoption_request][:include_completed] unless params[:adoption_request].nil?
 
     if include_completed == "1"
-      @adoption_requests = AdoptionRequest.all
+      @adoption_requests = AdoptionRequest.includes( :zone ).load
       @include_completed_checked = "checked"
     else
-      @adoption_requests = AdoptionRequest.all.where( :completed => false )
+      @adoption_requests = AdoptionRequest.includes( :zone ).where( :completed => false )
       @include_completed_checked = ""
     end
   end

--- a/app/controllers/adoption_requests_controller.rb
+++ b/app/controllers/adoption_requests_controller.rb
@@ -2,6 +2,7 @@ class AdoptionRequestsController < ApplicationController
   before_filter :require_user
 
   before_action :set_adoption_request, only: [:show, :edit, :update, :destroy]
+  before_action :handle_ignored, only: [:show, :edit, :update, :destroy]
 
   helper DateAndTimeHelper
 
@@ -69,7 +70,14 @@ class AdoptionRequestsController < ApplicationController
   # DELETE /adoption_requests/1
   # DELETE /adoption_requests/1.json
   def destroy
-    @adoption_request.destroy
+    # mark the record to be ignored by default
+    if params.has_key?('hard_delete') && params['hard_delete'] == 'yes'
+      @adoption_request.destroy
+    else
+      @adoption_request.ignore = true
+      @adoption_request.save!
+    end
+
     respond_to do |format|
       format.html { redirect_to session[:listing_referer] || adoption_requests_path }
       format.json { head :no_content }
@@ -82,12 +90,19 @@ class AdoptionRequestsController < ApplicationController
       @adoption_request = AdoptionRequest.find(params[:id])
     end
 
+    # records marked as ignored should be treated as if they don't exist
+    def handle_ignored
+      if @adoption_request.ignore == true
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+
     # Never trust parameters from the scary internet, only allow the white list through.
     def adoption_request_params
       params.require(:adoption_request).permit( :user_id, :tree_id, :owner_first_name, :owner_last_name,
         :owner_email, :owner_phone, :house_number, :street_name, :city, :state, :zip_code, :spanish_speaker,
         :room_for_tree, :concrete_removal, :wires, :source, :received_on, :contacted_on,
         :form_sent_to_cor_on, :site_assessed_on, :number_of_trees, :plant_space_width, :note,
-        :completed, :include_completed, :zone_id )
+        :completed, :include_completed, :zone_id, :hard_delete )
     end
 end

--- a/app/controllers/plantings_controller.rb
+++ b/app/controllers/plantings_controller.rb
@@ -11,7 +11,9 @@ class PlantingsController < ApplicationController
   def index
     store_listing_referer
 
-    @plantings = Planting.includes( { :parent_adoption_request => :zone }, { :notes => :created_by }, :tree_species ).order( "adoption_requests.street_name, adoption_requests.house_number" )
+    @plantings = Planting.includes( { :parent_adoption_request => :zone }, { :notes => :created_by }, :tree_species )
+      .where.not( ignore: true )
+      .order( "adoption_requests.street_name, adoption_requests.house_number" )
 
     respond_to do |format|
       format.html

--- a/app/controllers/plantings_controller.rb
+++ b/app/controllers/plantings_controller.rb
@@ -1,7 +1,8 @@
 class PlantingsController < ApplicationController
   before_filter :require_user
-  
+
   before_action :set_planting, only: [:show, :edit, :update, :destroy]
+  before_action :handle_ignored, only: [:show, :edit, :update, :destroy]
 
   helper DateAndTimeHelper
 
@@ -11,7 +12,7 @@ class PlantingsController < ApplicationController
     store_listing_referer
 
     @plantings = Planting.joins( :parent_adoption_request ).order( "adoption_requests.street_name, adoption_requests.house_number" )
-  
+
     respond_to do |format|
       format.html
       format.csv { send_data @plantings.to_csv }
@@ -78,7 +79,14 @@ class PlantingsController < ApplicationController
   # DELETE /plantings/1
   # DELETE /plantings/1.json
   def destroy
-    @planting.destroy
+    # mark the record to be ignored by default
+    if params.has_key?('hard_delete') && params['hard_delete'] == 'yes'
+      @planting.destroy
+    else
+      @planting.ignore = true
+      @planting.save
+    end
+
     respond_to do |format|
       format.html { redirect_to session[:listing_referer] || plantings_url }
       format.json { head :no_content }
@@ -91,9 +99,17 @@ class PlantingsController < ApplicationController
       @planting = Planting.find(params[:id])
     end
 
+    # records marked as ignored should be treated as if they don't exist
+    def handle_ignored
+      if @planting.ignore == true
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+
     # Never trust parameters from the scary internet, only allow the white list through.
     def planting_params
       params.require(:planting).permit(:adoption_request_id, :tree_id, :planted_on, :event, :placement,
-                                       :plant_space_width, :stakes_removed, :user_id, :initial_checks_received)
+                                       :plant_space_width, :stakes_removed, :user_id, :initial_checks_received,
+                                       :hard_delete)
     end
 end

--- a/app/controllers/plantings_controller.rb
+++ b/app/controllers/plantings_controller.rb
@@ -11,7 +11,7 @@ class PlantingsController < ApplicationController
   def index
     store_listing_referer
 
-    @plantings = Planting.joins( :parent_adoption_request ).order( "adoption_requests.street_name, adoption_requests.house_number" )
+    @plantings = Planting.includes( { :parent_adoption_request => :zone }, { :notes => :created_by }, :tree_species ).order( "adoption_requests.street_name, adoption_requests.house_number" )
 
     respond_to do |format|
       format.html

--- a/app/controllers/plantings_controller.rb
+++ b/app/controllers/plantings_controller.rb
@@ -84,7 +84,7 @@ class PlantingsController < ApplicationController
       @planting.destroy
     else
       @planting.ignore = true
-      @planting.save
+      @planting.save!
     end
 
     respond_to do |format|

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -4,6 +4,7 @@ module ReportsHelper
   def search_plantings( p )
     q = Planting.joins( :parent_adoption_request, :tree_species )
       .joins( 'LEFT JOIN "notes" ON "notes"."planting_id" = "plantings"."id"' )
+      .where.not( ignore: true )
       .where( plantings: { planted_on: Date.parse( p['planted_on_from'] )..Date.parse( p['planted_on_to'] ) } )
       .where( "adoption_requests.owner_first_name ILIKE ?", wildcard_if_empty( p['owner_first_name'] ) )
       .where( "adoption_requests.owner_last_name ILIKE ?", wildcard_if_empty( p['owner_last_name'] ) )
@@ -18,6 +19,8 @@ module ReportsHelper
       note_clause += " OR notes.note is null"
     end
     q = q.where( note_clause, wildcard_if_empty( p['note'] ) )
+
+    q = q.where.not( notes: { ignore: true } )
 
     last_maintenance_date_clause = '( "plantings"."last_maintenance_date" BETWEEN \'' + p['last_maintenance_from'] + '\' AND \'' + p['last_maintenance_to'] + '\' )'
     if p['include_nil_maintenance_records'] == 'yes'
@@ -54,6 +57,7 @@ module ReportsHelper
   # Plantings report
   def search_adoption_requests( p )
     q = AdoptionRequest
+      .where.not( ignore: true )
       .where( "street_name ILIKE ?", wildcard_if_empty( p['street_name'] ) )
       .where( "zip_code ILIKE ?", wildcard_if_empty( p['zip_code'] ) )
 

--- a/app/models/planting.rb
+++ b/app/models/planting.rb
@@ -9,9 +9,11 @@ class Planting < ActiveRecord::Base
 
   # get the most recent maintenance record or nil if there are none
   def most_recent_maintenance_record
-  	nil if self.id.nil? 
+  	nil if self.id.nil?
 
-    mr = MaintenanceRecord.where( planting_id: self.id ).order( :maintenance_date ).reverse_order.limit( 1 )
+    mr = MaintenanceRecord.where( planting_id: self.id )
+    mr = mr.where.not( ignore: true )
+    mr = mr.order( :maintenance_date ).reverse_order.limit( 1 )
     mr[ 0 ]
   end
 
@@ -50,7 +52,7 @@ class Planting < ActiveRecord::Base
 
   def self.to_csv
     attributes = %w[ id planted_on house_number street_name placement tree_common_name last_maintenance_date last_status_code last_note ]
-    
+
     CSV.generate( headers: true ) do |csv|
       csv << attributes
 

--- a/db/migrate/20160209201304_add_default_value_for_ignore_fields.rb
+++ b/db/migrate/20160209201304_add_default_value_for_ignore_fields.rb
@@ -1,0 +1,8 @@
+class AddDefaultValueForIgnoreFields < ActiveRecord::Migration
+  def change
+    change_column :plantings, :ignore, :boolean, :default => false
+    change_column :maintenance_records, :ignore, :boolean, :default => false
+    change_column :notes, :ignore, :boolean, :default => false
+    change_column :adoption_requests, :ignore, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160207080732) do
+ActiveRecord::Schema.define(version: 20160209201304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 20160207080732) do
     t.decimal  "latitude",            precision: 10, scale: 6
     t.decimal  "longitude",           precision: 10, scale: 6
     t.integer  "zone_id"
-    t.boolean  "ignore"
+    t.boolean  "ignore",                                       default: false
   end
 
   add_index "adoption_requests", ["user_id"], name: "index_adoption_requests_on_user_id", using: :btree
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20160207080732) do
     t.datetime "updated_at"
     t.date     "maintenance_date"
     t.integer  "user_id"
-    t.boolean  "ignore"
+    t.boolean  "ignore",                 default: false
   end
 
   add_index "maintenance_records", ["planting_id"], name: "index_maintenance_records_on_planting_id", using: :btree
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 20160207080732) do
     t.integer  "planting_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "ignore"
+    t.boolean  "ignore",      default: false
   end
 
   add_index "notes", ["planting_id"], name: "index_notes_on_planting_id", using: :btree
@@ -93,7 +93,7 @@ ActiveRecord::Schema.define(version: 20160207080732) do
     t.date     "last_maintenance_date"
     t.string   "last_status_code"
     t.boolean  "initial_checks_received"
-    t.boolean  "ignore"
+    t.boolean  "ignore",                  default: false
   end
 
   add_index "plantings", ["adoption_request_id"], name: "index_plantings_on_adoption_request_id", using: :btree

--- a/test/controllers/adoption_requests_controller_test.rb
+++ b/test/controllers/adoption_requests_controller_test.rb
@@ -60,11 +60,30 @@ class AdoptionRequestsControllerTest < ActionController::TestCase
     assert_redirected_to adoption_request_path(assigns(:adoption_request))
   end
 
-  test "should destroy adoption_request" do
-    assert_difference('AdoptionRequest.count', -1) do
-      delete :destroy, id: @adoption_request
+  describe "when deleting an adoption_request" do
+    it "should be deleted when passed a \"hard_delete\" parameter with the value of \"yes\"" do
+      assert_difference('AdoptionRequest.count', -1) do
+        delete :destroy, { id: @adoption_request, "hard_delete" => "yes" }
+      end
+
+      assert_redirected_to adoption_requests_path
     end
 
-    assert_redirected_to adoption_requests_path
+    it "should be marked as ignored by default" do
+      assert_difference('AdoptionRequest.count', 0) do
+        delete :destroy, id: @adoption_request
+      end
+
+      ar = AdoptionRequest.find(@adoption_request.id)
+      assert_equal true, ar.ignore
+      assert_redirected_to adoption_requests_path
+    end
+  end
+
+  describe "when attempting to access an ignored record" do
+    it "should be treated as if it doesn't exist" do
+      ignored = adoption_requests( :ignored )
+      assert_raises( ActiveRecord::RecordNotFound ) { get :show, id: ignored }
+    end
   end
 end

--- a/test/controllers/plantings_controller_test.rb
+++ b/test/controllers/plantings_controller_test.rb
@@ -82,4 +82,11 @@ class PlantingsControllerTest < ActionController::TestCase
       assert_redirected_to plantings_path
     end
   end
+
+  describe "when attempting to access an ignored record" do
+    it "should be treated as if it doesn't exist" do
+      ignored = plantings( :ignored )
+      assert_raises( ActiveRecord::RecordNotFound ) { get :show, id: ignored }
+    end
+  end
 end

--- a/test/controllers/plantings_controller_test.rb
+++ b/test/controllers/plantings_controller_test.rb
@@ -63,11 +63,23 @@ class PlantingsControllerTest < ActionController::TestCase
     assert_redirected_to planting_path(assigns(:planting))
   end
 
-  test "should destroy planting" do
-    assert_difference('Planting.count', -1) do
-      delete :destroy, id: @planting
+  describe "when deleting a planting" do
+    it "should be deleted when passed a \"hard_delete\" parameter with the value of \"yes\"" do
+      assert_difference('Planting.count', -1) do
+        delete :destroy, { id: @planting, "hard_delete" => "yes" }
+      end
+
+      assert_redirected_to plantings_path
     end
 
-    assert_redirected_to plantings_path
+    it "should be marked as ignored by default" do
+      assert_difference('Planting.count', 0) do
+        delete :destroy, id: @planting
+      end
+
+      p = Planting.find(@planting.id)
+      assert p.ignore, "planting ignore field should be true"
+      assert_redirected_to plantings_path
+    end
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -52,7 +52,7 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   test "should not destroy user with foreign key references" do
-    assert_no_difference('User.count', -1) do
+    assert_no_difference('User.count') do
       delete :destroy, id: @user
     end
 

--- a/test/fixtures/adoption_requests.yml
+++ b/test/fixtures/adoption_requests.yml
@@ -17,6 +17,8 @@ one:
   owner_phone: "123-123-1234"
   user_id: 1
   zone_id: 1
+  received_on: '2015-01-01'
+  ignore: false
 
 empty:
   id: 2
@@ -30,4 +32,20 @@ empty:
   owner_email:
   owner_phone:
   user_id: 1
-#  column: value
+  received_on: '2015-01-01'
+  ignore: false
+
+ignored:
+  id: 3
+  house_number: 2350
+  street_name: "Kerner Blvd"
+  city: "San Rafael"
+  state: "CA"
+  zip_code: 94901
+  owner_first_name: "Gerry"
+  owner_last_name: "Mander"
+  owner_email: "gerry@mander.com"
+  owner_phone:
+  user_id: 1
+  received_on: '2016-12-25'
+  ignore: true

--- a/test/fixtures/maintenance_records.yml
+++ b/test/fixtures/maintenance_records.yml
@@ -4,14 +4,25 @@ one:
   planting_id: 1
   maintenance_date: 2015-01-01
   status_code: A
-  reason_codes: 
+  reason_codes:
   diameter_breast_height: "2"
   user_id: 1
+  ignore: false
 
 two:
   planting_id: 1
   maintenance_date: 2015-12-01
   status_code: U
-  reason_codes: 
+  reason_codes:
   diameter_breast_height: "4"
   user_id: 1
+  ignore: false
+
+ignored:
+  planting_id: 1
+  maintenance_date: 2015-12-01
+  status_code: U
+  reason_codes:
+  diameter_breast_height: "4"
+  user_id: 1
+  ignore: true

--- a/test/fixtures/maintenance_records.yml
+++ b/test/fixtures/maintenance_records.yml
@@ -20,7 +20,7 @@ two:
 
 ignored:
   planting_id: 1
-  maintenance_date: 2015-12-01
+  maintenance_date: 2016-02-01
   status_code: U
   reason_codes:
   diameter_breast_height: "4"

--- a/test/fixtures/notes.yml
+++ b/test/fixtures/notes.yml
@@ -4,5 +4,10 @@ one:
   planting_id: 1
   user_id: 1
   note: This is a test note.
+  ignore: false
 
-two: {}
+ignored:
+  planting_id: 1
+  user_id: 1
+  note: This test note should be ignored.
+  ignore: true

--- a/test/fixtures/plantings.yml
+++ b/test/fixtures/plantings.yml
@@ -11,6 +11,7 @@ one:
   plant_space_width: "2x4"
   user_id: 1
   planted_on: "2015-01-01"
+  ignore: false
 
 two:
   id: 2
@@ -18,3 +19,12 @@ two:
   tree_id: 1
   plant_space_width: "4'"
   user_id: 1
+  ignore: false
+
+ignored:
+  id: 3
+  adoption_request_id: 2
+  tree_id: 1
+  plant_space_width: "4'"
+  user_id: 1
+  ignore: true

--- a/test/models/planting_test.rb
+++ b/test/models/planting_test.rb
@@ -9,7 +9,7 @@ class PlantingTest < ActiveSupport::TestCase
   end
 
   describe "most_recent_maintenance_record method" do
-    it "returns the most recent maintenance record for a planting" do
+    it "returns the most recent, non-deleted/ignored, maintenance record for a planting" do
       mr = maintenance_records( :two )
       @planting.most_recent_maintenance_record.maintenance_date.must_equal mr.maintenance_date
     end
@@ -73,7 +73,7 @@ class PlantingTest < ActiveSupport::TestCase
   describe ".to_csv" do
     it "returns the relation in csv format" do
       @plantings = Planting.all
-      
+
       # simple test - just count the number of lines
       output = @plantings.to_csv
       output.count("\n").must_equal @plantings.count+1


### PR DESCRIPTION
Adoption requests, plantings, maintenance records and notes are now marked as "ignored" on delete.  The api is still capable of doing full deletes.  Users, zones, and trees do not behave this way as they are altered much less frequently and referential integrity is protected at the database layer.
